### PR TITLE
DS-12787: rebrand API docs to RewardSTACK™

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,8 +1,8 @@
 openapi: 3.1.1
 info:
   version: '2.14.3'
-  title: ADR Marketplace Platform
-  description: ADR marketplace management API.
+  title: ADR RewardSTACK™ Platform
+  description: ADR RewardSTACK™ management API.
   contact:
     email: technology@alldigitalrewards.com
 servers:


### PR DESCRIPTION
## Summary
- Updates `openapi.yaml` `info.title` to **ADR RewardSTACK™ Platform** and `info.description` to **ADR RewardSTACK™ management API.**
- Supports the USPTO RewardSTACK™ trademark specimen submission, which requires the mark to be prominently displayed on a publicly reachable API documentation page.
- JIRA: [DS-12787](https://alldigitalrewards.atlassian.net/browse/DS-12787)

## Test plan
- [ ] Render the published Swagger/Redoc docs and confirm the page title shows "ADR RewardSTACK™ Platform"
- [ ] Confirm the description renders as "ADR RewardSTACK™ management API." with the ™ glyph intact
- [ ] Validate `openapi.yaml` parses cleanly (e.g. `npx @redocly/cli lint openapi.yaml` or equivalent)
- [ ] Capture a screenshot of the rendered docs page for the trademark specimen package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DS-12787]: https://alldigitalrewards.atlassian.net/browse/DS-12787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ